### PR TITLE
chore: Use FIT r-universe

### DIFF
--- a/fims_in_parallel/fims_in_parallel.R
+++ b/fims_in_parallel/fims_in_parallel.R
@@ -4,7 +4,7 @@
 # mkdir -p ~/R/bai-li-library/4.4
 # echo 'R_LIBS_USER="~/R/bai-li-library/4.4"' >> ~/.Renviron
 
-# install.packages("FIMS", repos = c("https://noaa-fims.r-universe.dev", "https://cloud.r-project.org"))
+# install.packages("FIMS", repos = c("https://noaa-fisheries-integrated-toolbox.r-universe.dev", "https://cloud.r-project.org"))
 devtools::install_github(
   "NOAA-FIMS/FIMS",
   ref = "2338d23eda72676ba3ac79dc8007ecec600979a6"


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* We are removing the NOAA R-universe, and thus this reference needs to change to the FIT r-universe

# How have you implemented the solution?
* Changed `https://noaa-fims.r-universe.dev` to `https://noaa-fisheries-integrated-toolbox.r-universe.dev`

# Does the PR impact any other area of the project, maybe another repo?
* No
